### PR TITLE
fix: use correct training when editing

### DIFF
--- a/src/authed-app.tsx
+++ b/src/authed-app.tsx
@@ -58,11 +58,12 @@ const AuthedApp = () => {
   };
 
   const handleSetEdit = (id: number) => {
-    if (!trainings || !trainings[id]) {
+    const training = trainings?.find((training) => training.id === id);
+    if (!training) {
       return;
     }
 
-    const trainingInput = createTrainingInput(trainings[id]);
+    const trainingInput = createTrainingInput(training);
     setCurrentInput(trainingInput);
     setMode("edit");
     setEditId(id);
@@ -74,6 +75,8 @@ const AuthedApp = () => {
     );
     deleteTraining(id, logout);
   };
+
+  console.log(trainings);
 
   return (
     <div className="authed">

--- a/src/trainings-table.tsx
+++ b/src/trainings-table.tsx
@@ -34,12 +34,12 @@ export const TrainingsTable = ({
                   >
                     edit
                   </button>
-                  {/* <button
+                  <button
                     className="btn-red"
                     onClick={() => handleDelete(training.id)}
                   >
                     x
-                  </button> */}
+                  </button>
                 </div>
               </div>
             );


### PR DESCRIPTION
When handling edit we used the id as an index lookup in the trainings array. This does not work if the order of the trainings is changed or a trainings is being removed. Therefore the training which should be edited is attained via the find method.